### PR TITLE
Fix filtering of indicator in dashboard

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -3,15 +3,29 @@ from database import SessionLocal, Activity, Program, Indicator
 import plotly.express as px
 
 def get_activities_df(filters: dict) -> pd.DataFrame:
+    """Return activities joined with their program and indicator."""
     db = SessionLocal()
-    q = db.query(Activity, Program.code.label("program"), Indicator.name.label("indicator"))           .join(Program, Activity.program_id == Program.id)           .join(Indicator, Activity.indicator_id == Indicator.id)
+    q = (
+        db.query(
+            Activity,
+            Program.code.label("program"),
+            Indicator.name.label("indicator"),
+        )
+        .join(Program, Activity.program_id == Program.id)
+        .join(Indicator, Activity.indicator_id == Indicator.id)
+    )
     for field, val in filters.items():
-        if val and hasattr(Activity, field):
-            q = q.filter(getattr(Activity, field) == val)
-        elif field == "program" and val != "ALL":
+        if not val:
+            continue
+        if field == "program" and val != "ALL":
             q = q.filter(Program.code == val)
+        elif field == "indicator":
+            q = q.filter(Indicator.name == val)
+        elif hasattr(Activity, field):
+            q = q.filter(getattr(Activity, field) == val)
     df = pd.read_sql(q.statement, db.bind)
     db.close()
+
     return df
 
 def plot_status_breakdown(df: pd.DataFrame):


### PR DESCRIPTION
## Summary
- handle indicator filter using `Indicator.name`
- format dashboard query for readability

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a8da2a9f4832b96b4189519442483