### PR TITLE
Fix ExcelWriter usage in template generation

### DIFF
--- a/report_export.py
+++ b/report_export.py
@@ -9,6 +9,5 @@ def export_to_excel(df_dict: dict):
     with pd.ExcelWriter(out, engine="xlsxwriter") as writer:
         for sheet, df in df_dict.items():
             df.to_excel(writer, sheet_name=sheet, index=False)
-    writer.save()
     out.seek(0)
     return out

--- a/templates.py
+++ b/templates.py
@@ -9,7 +9,6 @@ def make_config_template() -> BytesIO:
         cfg["programs"].to_excel(writer, sheet_name="Programs", index=False)
         cfg["pillars"].to_excel(writer, sheet_name="Pillars", index=False)
         cfg["indicators"].to_excel(writer, sheet_name="Indicators", index=False)
-    writer.save()
     out.seek(0)
     return out
 
@@ -29,6 +28,5 @@ def make_data_template() -> BytesIO:
             "title": ""
         }])
         df_act.to_excel(writer, sheet_name="Activities", index=False)
-    writer.save()
     out.seek(0)
     return out


### PR DESCRIPTION
## Summary
- remove obsolete `writer.save()` calls from Excel export helpers

## Testing
- `python -m pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_685a8dcb5354832b8ff815f3e3a144c7